### PR TITLE
Corrected test resource name typo

### DIFF
--- a/core/src/test/java/de/joerghoh/cqdump/samples/unittest/models/NavigationModelTest.java
+++ b/core/src/test/java/de/joerghoh/cqdump/samples/unittest/models/NavigationModelTest.java
@@ -29,7 +29,7 @@ public class NavigationModelTest {
     
     @Before
     public void setup() {
-        context.load().json(NavigationModelTest.class.getResourceAsStream("NavigationModeltest.json"), "/content");
+        context.load().json(NavigationModelTest.class.getResourceAsStream("NavigationModelTest.json"), "/content");
     }
     
     


### PR DESCRIPTION
There was a typo in the filename which described the mock resource. Test is currently not successful with this typo and will output a NullPointerException
